### PR TITLE
Sentry: set plugin context in more cases + Add Tags

### DIFF
--- a/patches/api/0001-Add-Sentry.patch
+++ b/patches/api/0001-Add-Sentry.patch
@@ -183,6 +183,49 @@ index 0000000000000000000000000000000000000000..10310fdd53de28efb8a8250f6d3b0c8e
 +		}
 +	}
 +}
+diff --git a/src/main/java/org/bukkit/command/PluginCommand.java b/src/main/java/org/bukkit/command/PluginCommand.java
+index 551c5af6a7bfa2268cbc63be8e70d129bccaa912..610c89d50b7f29e5f6ffce75feaa92a6a484f79b 100644
+--- a/src/main/java/org/bukkit/command/PluginCommand.java
++++ b/src/main/java/org/bukkit/command/PluginCommand.java
+@@ -32,12 +32,14 @@ public final class PluginCommand extends Command implements PluginIdentifiableCo
+     @Override
+     public boolean execute(@NotNull CommandSender sender, @NotNull String commandLabel, @NotNull String[] args) {
+         boolean success = false;
++        gg.pufferfish.pufferfish.sentry.SentryContext.setPluginContext(owningPlugin); // Pufferfish
+ 
+         if (!owningPlugin.isEnabled()) {
+             throw new CommandException("Cannot execute command '" + commandLabel + "' in plugin " + owningPlugin.getDescription().getFullName() + " - plugin is disabled.");
+         }
+ 
+         if (!testPermission(sender)) {
++            gg.pufferfish.pufferfish.sentry.SentryContext.removePluginContext(); // Pufferfish
+             return true;
+         }
+ 
+@@ -53,6 +55,7 @@ public final class PluginCommand extends Command implements PluginIdentifiableCo
+             }
+         }
+ 
++        gg.pufferfish.pufferfish.sentry.SentryContext.removePluginContext(); // Pufferfish
+         return success;
+     }
+ 
+@@ -132,6 +135,7 @@ public final class PluginCommand extends Command implements PluginIdentifiableCo
+         Preconditions.checkArgument(args != null, "Arguments cannot be null");
+         Preconditions.checkArgument(alias != null, "Alias cannot be null");
+ 
++        gg.pufferfish.pufferfish.sentry.SentryContext.setPluginContext(owningPlugin); // Pufferfish
+         List<String> completions = null;
+         try {
+             if (completer != null) {
+@@ -150,6 +154,7 @@ public final class PluginCommand extends Command implements PluginIdentifiableCo
+             throw new CommandException(message.toString(), ex);
+         }
+ 
++        gg.pufferfish.pufferfish.sentry.SentryContext.removePluginContext(); // Pufferfish
+         if (completions == null) {
+             return super.tabComplete(sender, alias, args);
+         }
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 index 2b8308989fce7f8a16907f8711b362e671fdbfb6..bd4d1a40f53784662174d426533ef4b5433a15b7 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java

--- a/patches/server/0005-Add-Sentry.patch
+++ b/patches/server/0005-Add-Sentry.patch
@@ -26,10 +26,10 @@ index d1a8bfb29817d2b73689713b4d5f04d7f2c0eaf4..5b7fe3d6c2169d07b79a0937e889fc84
  }
 diff --git a/src/main/java/gg/pufferfish/pufferfish/sentry/PufferfishSentryAppender.java b/src/main/java/gg/pufferfish/pufferfish/sentry/PufferfishSentryAppender.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..731ef11c7a025ae95ed8a757b530d834733d0621
+index 0000000000000000000000000000000000000000..d3bf6da35a5ad1a8eedb839c076a02eb1c6efa08
 --- /dev/null
 +++ b/src/main/java/gg/pufferfish/pufferfish/sentry/PufferfishSentryAppender.java
-@@ -0,0 +1,135 @@
+@@ -0,0 +1,140 @@
 +package gg.pufferfish.pufferfish.sentry;
 +
 +import com.google.common.reflect.TypeToken;
@@ -84,6 +84,7 @@ index 0000000000000000000000000000000000000000..731ef11c7a025ae95ed8a757b530d834
 +		event.setThrowable(e.getThrown());
 +		event.setLevel(getLevel(e.getLevel()));
 +		event.setLogger(e.getLoggerName());
++		event.setTag("Logger", e.getLoggerName());
 +		event.setTransaction(e.getLoggerName());
 +		event.setExtra("thread_name", e.getThreadName());
 +		
@@ -100,6 +101,10 @@ index 0000000000000000000000000000000000000000..731ef11c7a025ae95ed8a757b530d834
 +			event.setExtra("plugin.name", e.getContextData().getValue("pufferfishsentry_pluginname"));
 +			event.setExtra("plugin.version", e.getContextData().getValue("pufferfishsentry_pluginversion"));
 +			event.setTransaction(e.getContextData().getValue("pufferfishsentry_pluginname"));
++			event.setTag("Plugin", e.getContextData().getValue("pufferfishsentry_pluginname"));
++			// Command errors handling is very intricate, we remove the context here,
++			// it is removed at the end of the command execution if it was successful
++			SentryContext.removePluginContext();
 +		}
 +		
 +		if (hasContext && e.getContextData().containsKey("pufferfishsentry_eventdata")) {
@@ -211,3 +216,20 @@ index 0000000000000000000000000000000000000000..1b29210ad0bbb4ada150f23357f0c80d
 +	}
 +	
 +}
+diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
+index cdefb2025eedea7e204d70d568adaf1c1ec4c03c..f514a115f85d16b2c08ec5ec078e4b88af554cad 100644
+--- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
++++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
+@@ -490,10 +490,12 @@ public class CraftScheduler implements BukkitScheduler {
+                     if (task.getOwner() == MINECRAFT) {
+                         net.minecraft.server.MinecraftServer.LOGGER.error(msg, throwable);
+                     } else {
++                        gg.pufferfish.pufferfish.sentry.SentryContext.setPluginContext(task.getOwner()); // Pufferfish
+                         task.getOwner().getLogger().log(
+                             Level.WARNING,
+                             msg,
+                             throwable);
++                        gg.pufferfish.pufferfish.sentry.SentryContext.removePluginContext(); // Pufferfish
+                     }
+                     org.bukkit.Bukkit.getServer().getPluginManager().callEvent(
+                         new ServerExceptionEvent(new ServerSchedulerException(msg, throwable, task)));


### PR DESCRIPTION
This PR does the following changes:
- Set the Plugin context for command execution and command tab completion
- Set the Plugin context for BukkitRunnables
- Add a `Logger` tag to simplify issues filtering in Sentry
- Add a `Plugin` tag when possible to simplify issues filtering in Sentry

I will happily apply the requested modifications and hope you will find these changes relevant.